### PR TITLE
Fix t-test in discipline analysis and add test

### DIFF
--- a/schoolboard/__init__.py
+++ b/schoolboard/__init__.py
@@ -1,0 +1,1 @@
+"""Utilities for schoolboard data analysis."""

--- a/schoolboard/discipline.py
+++ b/schoolboard/discipline.py
@@ -4,6 +4,8 @@ Created on Mon Mar  4 17:13:18 2024
 
 @author: BrownPlanning
 """
+from pathlib import Path
+
 import pandas as pd
 import scipy.stats as stats
 
@@ -16,7 +18,7 @@ def abbrev_level(text):
             return key
 
 def t_test(series):
-    t_statistic, p_value = stats.ttest_rel(series, [0] * len(series))
+    t_statistic, p_value = stats.ttest_1samp(series, 0)
     if p_value < 0.05:
         conclusion = 'There is a significant difference.'
         print(f"Reject null hypothesis for {series.name} p-value {p_value:.2f} {conclusion}")
@@ -28,27 +30,29 @@ def t_test(series):
 def convert_to_numeric(column):
     return pd.to_numeric(column.str.replace(',', ''), errors='coerce')
 
-df = pd.read_csv('Behavior_20240131.csv')
+if __name__ == "__main__":
+    data_file = Path(__file__).with_name("Behavior_20240131.csv")
+    df = pd.read_csv(data_file)
 
-months = [list(df.columns[2:])[i] for i in range(0, len(df.columns[2:]), 2)]
-years = sorted(list(set(df.iloc[0, 2:].values.tolist())))
-colnames = [f'{month} {year}' for month in months for year in years]
-df.columns = list(df.columns[:2]) + colnames
-df = df.drop(0)  # drop years row
-df[colnames] = df[colnames].apply(convert_to_numeric)
+    months = [list(df.columns[2:])[i] for i in range(0, len(df.columns[2:]), 2)]
+    years = sorted(list(set(df.iloc[0, 2:].values.tolist())))
+    colnames = [f"{month} {year}" for month in months for year in years]
+    df.columns = list(df.columns[:2]) + colnames
+    df = df.drop(0)  # drop years row
+    df[colnames] = df[colnames].apply(convert_to_numeric)
 
-# Select rows where 'School Type' contains 'Total'
-totals = df[df['School Type'].str.contains('Total', na=False)]
-totals = totals.drop('Behavior Category', axis=1)
-totals['School Type'] = totals['School Type'].apply(abbrev_level)
+    # Select rows where 'School Type' contains 'Total'
+    totals = df[df['School Type'].str.contains('Total', na=False)]
+    totals = totals.drop('Behavior Category', axis=1)
+    totals['School Type'] = totals['School Type'].apply(abbrev_level)
 
-differences = pd.DataFrame()
-differences['School Type'] = totals['School Type']
-columns_to_rename = list(totals.columns[1:])
-for month in months:
-    last_year, curr_year = [f'{month} {year}' for year in years]
-    differences[month] = totals[curr_year] - totals[last_year]
-differences = differences.set_index('School Type')
-differences = differences.transpose()
+    differences = pd.DataFrame()
+    differences['School Type'] = totals['School Type']
+    columns_to_rename = list(totals.columns[1:])
+    for month in months:
+        last_year, curr_year = [f"{month} {year}" for year in years]
+        differences[month] = totals[curr_year] - totals[last_year]
+    differences = differences.set_index('School Type')
+    differences = differences.transpose()
 
-differences.apply(t_test)
+    differences.apply(t_test)

--- a/tests/test_discipline.py
+++ b/tests/test_discipline.py
@@ -1,0 +1,15 @@
+import os
+import sys
+
+import pandas as pd
+from scipy import stats
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from schoolboard import discipline
+
+def test_t_test_matches_ttest_1samp():
+    data = pd.Series([1.0, 2.0, 3.0], name="demo")
+    expected = stats.ttest_1samp(data, 0).pvalue
+    result = discipline.t_test(data)
+    assert result == pytest.approx(expected)


### PR DESCRIPTION
## Summary
- use one-sample t-test in `schoolboard.discipline.t_test` to measure differences against zero
- guard script execution with `__main__` and read CSV via relative path
- add unit test for `t_test`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68ab82a02cfc832097984d961f11bfaf